### PR TITLE
mkdir: added verbose flag, changed error handling method

### DIFF
--- a/mkdir/mkdir.go
+++ b/mkdir/mkdir.go
@@ -9,7 +9,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
 	"os"
 )
 
@@ -21,6 +20,7 @@ const (
         --version     output version information and exit
         --parents     create parent directory/directories as 
                       needed, do nothing if already existing
+        --verbose     print a message for each created directory
   `
 
 	version_text = `
@@ -37,13 +37,16 @@ const (
     already exist, do nothing. 
   `
 
-	usage_text = `usage: mkdir [-parents] directory ...`
+	usage_text = `usage: mkdir [-parents, -verbose] directory ...`
+
+	verbose_text = `Print a message for each created directory.`
 )
 
 var (
 	help    = flag.Bool("help", false, help_text)
 	version = flag.Bool("version", false, version_text)
 	parents = flag.Bool("parents", false, parents_text)
+	verbose = flag.Bool("verbose", false, verbose_text)
 )
 
 func main() {
@@ -69,13 +72,17 @@ func main() {
 			mkdirAllError := os.MkdirAll(flag.Arg(i), os.ModePerm)
 
 			if mkdirAllError != nil {
-				log.Fatalln(mkdirAllError)
+				fmt.Println(mkdirAllError)
+			} else if *verbose {
+				fmt.Printf("%s\n", flag.Arg(i))
 			}
 		} else {
 			mkdirError := os.Mkdir(flag.Arg(i), os.ModePerm)
 
 			if mkdirError != nil {
-				log.Fatalln(mkdirError)
+				fmt.Println(mkdirError)
+			} else if *verbose {
+				fmt.Printf("mkdir: created directory '%s'\n", flag.Arg(i))
 			}
 		}
 	}


### PR DESCRIPTION
- The verbose flag needs more work in how it behaves with
  the -parents flag. To observe, compare output between this
  implementation and the actual mkdir, with both parent and
  verbose flags, and create a nested directory whose
  parent does not exist.
- When mkdir encounters errors, they are simply displayed.
  Any proceeding arguments are processed. Because the Fatal
  functions call os.Exit(1) and the Panic functions call
  panic after writing their log message, I removed usage of
  the log package and opted to simply display the error.
