### PR TITLE
ls.go: Code Improvement

### DIFF
--- a/ls/ls.go
+++ b/ls/ls.go
@@ -253,7 +253,7 @@ func printTopToBottom(fileList []string) {
 	numOfRows := countRows(&lastRowCount, &maxColumns, &numOfFiles) // Number of rows to print
 	printing := true                                                // Turn the printer on by default
 	var currentRow, currentIndex int = 1, 0
-	printingLayout := "%-"+fmt.Sprintf("%d", maxCharLength+SPACING)+"s"
+	printingLayout := "%-"+fmt.Sprintf("%d", maxCharLength+SPACING+7)+"s"
 
 	/* This our magnificent printing press. It will first start on the default case, which
 	 * will print the majority of the files from the first row all the way to the next to


### PR DESCRIPTION
- Split main into many smaller functions for easier readability.
- Removed the spacer function and instead use file statistics to generate a printf layout format.
- Almost completed all of the functionality of long mode. All that's really left is to make it display where symlinks are pointing. An example is shown below:

total: 9
 -rw-r--r-- mmstick mmstick      76 Jun 20 06:38 TODO
 -rw-r--r-- mmstick mmstick    4288 Jun 19 05:38 basename.go
 -rw-r--r-- mmstick mmstick    5537 Jun 19 04:39 date.go
 -rw-r--r-- mmstick mmstick    1906 Jun 19 05:40 dirname.go
 drwxr-xr-x mmstick mmstick     304 Jun 20 06:36 go-coreutils
 -rwxr-xr-x mmstick mmstick 2735472 Jun 20 07:11 ls
 -rw-r--r-- mmstick mmstick   14069 Jun 20 07:01 ls.go
 -rw-r--r-- mmstick mmstick     879 Jun 20 05:56 percent-change.go
 -rw-r--r-- mmstick mmstick    2837 Jun 18 16:51 test

Note: I've noticed that my implementation of long mode is significantly slower than GNU Coreutils. The time it takes to print /usr/bin is 230ms versus 70ms for GNU's C implementation.
