### PR TITLE
[tail] fix help_text. Command name is wrong

### DIFF
--- a/tail/tail.go
+++ b/tail/tail.go
@@ -16,7 +16,7 @@ import "strings"
 
 const (
 	help_text string = `
-    Usage: printTail [OPTION]... [FILE]...
+    Usage: tail [OPTION]... [FILE]...
        
     Print the last 10 lines of each FILE to standard output. With more than one FILE, precede
     each with a header giving the file name. With no FILE, or when FILE is -, read standard input.


### PR DESCRIPTION
Signed-off-by: Akira Hayakawa ruby.wktk@gmail.com
